### PR TITLE
Add build status and Go report card badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # The Blundering Savant AI Coding Agent
 
+[![Build Status](https://github.com/cchalm/blundering-savant/actions/workflows/go.yml/badge.svg)](https://github.com/cchalm/blundering-savant/actions/workflows/go.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cchalm/blundering-savant)](https://goreportcard.com/report/github.com/cchalm/blundering-savant)
+
 Blundering Savant is a generative AI coding agent that presents as a GitHub user. The agent receives instructions via
 issues, reviews, and comments and proposes code changes by creating and updating pull requests.
 


### PR DESCRIPTION
This PR addresses issue #18 by adding common badges to the README.

## Changes Made

- **Build Status Badge**: Shows the current status of the GitHub Actions "Go" workflow
- **Go Report Card Badge**: Displays code quality metrics from goreportcard.com

## Badge Details

Both badges are positioned prominently under the main title for immediate visibility:

1. **Build Status**: Links to the GitHub Actions workflow page, showing whether the latest build passed or failed
2. **Go Report Card**: Links to the Go Report Card page for this repository, providing insights into code quality, test coverage, and other metrics

The badges use standard GitHub badge formats and follow common conventions for Go projects.

Fixes #18

---
*This PR was created by the Blundering Savant bot.*