### PR TITLE
Add license badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/cchalm/blundering-savant/actions/workflows/go.yml/badge.svg)](https://github.com/cchalm/blundering-savant/actions/workflows/go.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cchalm/blundering-savant)](https://goreportcard.com/report/github.com/cchalm/blundering-savant)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Blundering Savant is a generative AI coding agent that presents as a GitHub user. The agent receives instructions via
 issues, reviews, and comments and proposes code changes by creating and updating pull requests.


### PR DESCRIPTION
Adds an MIT license badge to the README file to provide clear visibility of the project's licensing terms.

The badge is placed alongside the existing Build Status and Go Report Card badges for consistency and follows the standard shields.io format for MIT license badges.

Fixes #23

Fixes #23

---
*This PR was created by the Blundering Savant bot.*