### PR TITLE
Implement case for delete_file tool in toolSummary template function

### DIFF
--- a/cmd/blundering-savant/conversationmd.go
+++ b/cmd/blundering-savant/conversationmd.go
@@ -190,6 +190,15 @@ func renderConversationMarkdown(data *conversationMarkdownData) (string, error) 
 				return "🔍 Validating changes"
 			case "publish_changes_for_review":
 				return "📤 Publishing changes for review"
+			case "delete_file":
+				// Parse path from input for more specific summary
+				var input map[string]interface{}
+				if err := json.Unmarshal([]byte(toolInput), &input); err == nil {
+					if path, ok := input["path"].(string); ok && path != "" {
+						return fmt.Sprintf("🗑️ Deleting '%s'", path)
+					}
+				}
+				return "🗑️ Deleting file"
 			default:
 				return fmt.Sprintf("🔧 Using tool: %s", toolName)
 			}


### PR DESCRIPTION
This PR addresses issue #31 by implementing the missing case for the `delete_file` tool in the `toolSummary` template function within `cmd/blundering-savant/conversationmd.go`.

## Changes Made

- Added a new case for `"delete_file"` tool in the `toolSummary` function (lines 194-200)
- Extracts the `path` parameter from the tool input JSON to provide specific file information
- Uses the 🗑️ emoji icon to visually represent the delete operation
- Follows the same pattern as other tools with path-specific summaries
- Includes appropriate fallback to generic message if path parsing fails

## Implementation Details

The implementation follows the established patterns in the codebase:
- Parses the tool input JSON to extract the `path` parameter
- Returns a descriptive summary with the file path when available: `"🗑️ Deleting 'filename'"`
- Falls back to a generic summary if path parsing fails: `"🗑️ Deleting file"`
- Uses consistent emoji styling with other file operations in the function

This ensures that when the AI agent uses the `delete_file` tool, the conversation markdown will display a clear, human-readable summary of what file is being deleted.

Fixes #31

---
*This PR was created by the Blundering Savant bot.*