### PR TITLE
Split initial prompt into repository-specific and task-specific sections for cache optimization

### DIFF
--- a/cmd/blundering-savant/bot.go
+++ b/cmd/blundering-savant/bot.go
@@ -406,12 +406,22 @@ func (b *Bot) initConversation(ctx context.Context, tsk task, toolCtx *ToolConte
 		c := NewClaudeConversation(b.anthropicClient, model, maxTokens, tools, systemPrompt)
 
 		log.Printf("Sending initial message to AI")
+		
+		// Build repository-specific content (cacheable)
+		repositoryInfoPtr, err := BuildRepositoryInfo(tsk)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to build repository info: %w", err)
+		}
+
+		// Build task-specific content
 		promptPtr, err := BuildPrompt(tsk)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build prompt: %w", err)
 		}
 
-		response, err := c.SendMessage(ctx, anthropic.NewTextBlock(*promptPtr))
+		response, err := c.SendMessage(ctx, 
+			anthropic.NewTextBlock(*repositoryInfoPtr),
+			anthropic.NewTextBlock(*promptPtr))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to send initial message to AI: %w", err)
 		}

--- a/cmd/blundering-savant/prompt.go
+++ b/cmd/blundering-savant/prompt.go
@@ -14,6 +14,9 @@ import (
 //go:embed prompt_template.tmpl
 var promptTemplate string
 
+//go:embed repository_info_template.tmpl
+var repositoryInfoTemplate string
+
 // Custom types for template data to avoid pointer dereferencing in templates
 
 // userData represents a user in template data
@@ -61,16 +64,10 @@ type reviewCommentThreadData []reviewCommentData
 
 // promptTemplateData holds the data used to render the prompt template
 type promptTemplateData struct {
-	Repository             string
-	MainLanguage           string
 	IssueNumber            int
 	IssueTitle             string
 	IssueBody              string
 	PullRequestNumber      *int
-	StyleGuides            map[string]string // path -> content
-	ReadmeContent          string
-	FileTree               []string
-	FileTreeTruncatedCount int // The number of files that were truncated from the file tree to cap length
 	HasConversationHistory bool
 	// Conversation data structures for template to format
 	IssueComments                      []commentData
@@ -83,6 +80,37 @@ type promptTemplateData struct {
 	PRReviewCommentsRequiringResponses []reviewCommentData
 	HasUnpublishedChanges              bool
 	ValidationResult                   ValidationResult
+}
+
+// BuildRepositoryInfo generates the repository-specific content block for Claude
+func BuildRepositoryInfo(tsk task) (*string, error) {
+	data := buildRepositoryTemplateData(tsk)
+
+	// Create template with helper functions
+	funcMap := template.FuncMap{
+		"indent": func(prefix string, text string) string {
+			prefixed := strings.Builder{}
+			for line := range strings.Lines(text) {
+				prefixed.WriteString(prefix)
+				prefixed.WriteString(line)
+			}
+			return prefixed.String()
+		},
+	}
+
+	tmpl, err := template.New("repository_info").Funcs(funcMap).Parse(repositoryInfoTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse repository info template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute repository info template: %w", err)
+	}
+
+	result := buf.String()
+	return &result, nil
 }
 
 // BuildPrompt generates the complete prompt for Claude based on the context
@@ -235,11 +263,21 @@ func derefOr[T any](ptr *T, defaultVal T) T {
 	return *ptr
 }
 
-// buildTemplateData creates the data structure for template rendering
-func buildTemplateData(tsk task) promptTemplateData {
-	data := promptTemplateData{}
+// repositoryTemplateData holds repository-specific data that can be cached
+type repositoryTemplateData struct {
+	Repository             string
+	MainLanguage           string
+	StyleGuides            map[string]string // path -> content
+	ReadmeContent          string
+	FileTree               []string
+	FileTreeTruncatedCount int // The number of files that were truncated from the file tree to cap length
+}
 
-	// Basic repository and issue information
+// buildRepositoryTemplateData creates the repository-specific data structure for template rendering
+func buildRepositoryTemplateData(tsk task) repositoryTemplateData {
+	data := repositoryTemplateData{}
+
+	// Basic repository information
 	if tsk.Repository != nil && tsk.Repository.FullName != nil {
 		data.Repository = *tsk.Repository.FullName
 	} else {
@@ -251,15 +289,6 @@ func buildTemplateData(tsk task) promptTemplateData {
 	}
 	if data.MainLanguage == "" {
 		data.MainLanguage = "unknown"
-	}
-
-	data.IssueNumber = tsk.Issue.number
-	data.IssueTitle = tsk.Issue.title
-	data.IssueBody = tsk.Issue.body
-
-	// Pull request information
-	if tsk.PullRequest != nil {
-		data.PullRequestNumber = &tsk.PullRequest.number
 	}
 
 	// Style guides
@@ -282,6 +311,23 @@ func buildTemplateData(tsk task) promptTemplateData {
 				data.FileTree = tsk.CodebaseInfo.FileTree
 			}
 		}
+	}
+
+	return data
+}
+
+// buildTemplateData creates the data structure for template rendering
+func buildTemplateData(tsk task) promptTemplateData {
+	data := promptTemplateData{}
+
+	// Issue information
+	data.IssueNumber = tsk.Issue.number
+	data.IssueTitle = tsk.Issue.title
+	data.IssueBody = tsk.Issue.body
+
+	// Pull request information
+	if tsk.PullRequest != nil {
+		data.PullRequestNumber = &tsk.PullRequest.number
 	}
 
 	// Conversation history - convert GitHub types to template types

--- a/cmd/blundering-savant/prompt_template.tmpl
+++ b/cmd/blundering-savant/prompt_template.tmpl
@@ -1,7 +1,3 @@
-Repository: {{.Repository}}
-
-Main Language: {{.MainLanguage}}
-
 ## Issue
 
 Issue #{{.IssueNumber}}: {{.IssueTitle}}
@@ -14,40 +10,6 @@ Issue #{{.IssueNumber}}: {{.IssueTitle}}
 
 ## Pull Request
 Pull Request #{{.PullRequestNumber}} is open for this issue.
-{{- end}}
-{{- if .StyleGuides}}
-
-## Style Guides
-{{- range $path, $content := .StyleGuides}}
-
-<details>
-<summary>{{$path}}</summary>
-
-{{$content | indent "> "}}
-
-</details>
-{{- end}}
-{{- end}}
-{{- if .ReadmeContent}}
-
-## README excerpt
-
-{{.ReadmeContent | indent "> "}}
-{{- end}}
-{{- if .FileTree}}
-
-## Repository structure
-
-<details>
-<summary>View File Tree</summary>
-
-{{range .FileTree -}}
-- `{{.}}`
-{{end}}
-{{if .FileTreeTruncatedCount -}}
-... ({{.FileTreeTruncatedCount}} more files)
-{{- end}}
-</details>
 {{- end}}
 {{- if .HasConversationHistory}}
 

--- a/cmd/blundering-savant/repository_info_template.tmpl
+++ b/cmd/blundering-savant/repository_info_template.tmpl
@@ -1,0 +1,39 @@
+Repository: {{.Repository}}
+
+Main Language: {{.MainLanguage}}
+
+{{- if .StyleGuides}}
+
+## Style Guides
+{{- range $path, $content := .StyleGuides}}
+
+<details>
+<summary>{{$path}}</summary>
+
+{{$content | indent "> "}}
+
+</details>
+{{- end}}
+{{- end}}
+{{- if .ReadmeContent}}
+
+## README excerpt
+
+{{.ReadmeContent | indent "> "}}
+{{- end}}
+{{- if .FileTree}}
+
+## Repository structure
+
+<details>
+<summary>View File Tree</summary>
+
+{{range .FileTree -}}
+- `{{.}}`
+{{end}}
+{{if .FileTreeTruncatedCount -}}
+... ({{.FileTreeTruncatedCount}} more files)
+{{- end}}
+
+</details>
+{{- end}}


### PR DESCRIPTION
This PR addresses issue #25 by splitting the initial prompt into two separate content blocks to enable cache optimization for repository-specific information.

## Changes Made

### New Files
- **`repository_info_template.tmpl`**: Template for repository-specific content that can be cached between tasks (repository name, main language, style guides, README excerpt, file tree)

### Modified Files
- **`prompt.go`**: 
  - Added `BuildRepositoryInfo()` function to generate repository-specific content block
  - Added `repositoryTemplateData` struct for repository-specific template data
  - Added `buildRepositoryTemplateData()` function to populate repository data
  - Updated `promptTemplateData` struct to remove repository-specific fields
  - Modified `buildTemplateData()` to only handle task-specific data

- **`prompt_template.tmpl`**: 
  - Removed repository-specific sections (style guides, README excerpt, file tree)
  - Now focuses only on task-specific content (issue details, conversation history, workspace status, task instructions)

- **`bot.go`**: 
  - Updated `initConversation()` to send two separate content blocks: repository info first (cacheable), then task-specific content

## Cache Optimization Benefits

The split enables AI providers to cache the repository-specific content block (which is typically stable across tasks) while only processing the task-specific content block (which changes for each issue/task). This should result in:

1. **Faster response times** - cached repository content doesn't need reprocessing
2. **Lower costs** - reduced token processing for repeated repository information  
3. **Better performance** - more efficient use of AI model resources

## Testing

All existing tests pass, confirming the functionality remains intact while enabling the caching optimization.

Fixes #25

---
*This PR was created by the Blundering Savant bot.*