### PR TITLE
Report file-already-exists errors as ToolInputError

### DIFF
--- a/cmd/blundering-savant/bot.go
+++ b/cmd/blundering-savant/bot.go
@@ -74,7 +74,8 @@ type Workspace interface {
 	ValidateChanges(ctx context.Context, commitMessage *string) (ValidationResult, error)
 	// PublishChangesForReview makes validated changes available for review. reviewRequestTitle and reviewRequestBody
 	// are only used the first time a review is published, subsequent publishes will ignore these parameters and update
-	// the existing review
+	// the existing review. PublishChangesForReview will return an error if there are unvalidated local changes in the
+	// workspace; all local changes must be validated before calling PublishChangesForReview
 	PublishChangesForReview(ctx context.Context, reviewRequestTitle string, reviewRequestBody string) error
 }
 
@@ -406,7 +407,7 @@ func (b *Bot) initConversation(ctx context.Context, tsk task, toolCtx *ToolConte
 		// Send repository content as cacheable block, followed by task-specific content
 		repositoryBlock := anthropic.NewTextBlock(repositoryContent)
 		taskBlock := anthropic.NewTextBlock(taskContent)
-		
+
 		response, err := c.SendMessage(ctx, repositoryBlock, taskBlock)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to send initial message to AI: %w", err)

--- a/cmd/blundering-savant/tools.go
+++ b/cmd/blundering-savant/tools.go
@@ -749,6 +749,10 @@ func (t *PublishChangesForReviewTool) Run(ctx context.Context, block anthropic.T
 		}
 	}
 
+	if toolCtx.Workspace.HasLocalChanges() {
+		return nil, ToolInputError{fmt.Errorf("cannot publish while there are unvalidated changes in the workspace")}
+	}
+
 	err = toolCtx.Workspace.PublishChangesForReview(ctx, input.PullRequestTitle, input.PullRequestBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to publish changes: %w", err)
@@ -785,7 +789,7 @@ func NewReportLimitationTool() *ReportLimitationTool {
 // GetToolParam returns the tool parameter definition
 func (t *ReportLimitationTool) GetToolParam() anthropic.ToolParam {
 	return anthropic.ToolParam{
-		Name: t.Name,
+		Name:        t.Name,
 		Description: anthropic.String("Report when you need to perform an action that you don't have a tool for. Use this instead of trying workarounds with available tools."),
 		InputSchema: anthropic.ToolInputSchemaParam{
 			Properties: map[string]any{
@@ -840,11 +844,11 @@ func (t *ReportLimitationTool) Run(ctx context.Context, block anthropic.ToolUseB
 	report.WriteString("## Tool Limitation Report\n\n")
 	report.WriteString(fmt.Sprintf("**Action needed:** %s\n\n", input.Action))
 	report.WriteString(fmt.Sprintf("**Reason:** %s\n\n", input.Reason))
-	
+
 	if input.Suggestions != "" {
 		report.WriteString(fmt.Sprintf("**Suggestions:** %s\n\n", input.Suggestions))
 	}
-	
+
 	report.WriteString("This action cannot be performed with the currently available tools. ")
 	report.WriteString("Human intervention or additional tool support may be required.")
 

--- a/cmd/blundering-savant/validator.go
+++ b/cmd/blundering-savant/validator.go
@@ -209,7 +209,7 @@ func (gacv GithubActionCommitValidator) triggerWorkflowRun(ctx context.Context, 
 
 func (gacv GithubActionCommitValidator) waitForWorkflowStart(ctx context.Context, headSHA string) (*github.WorkflowRun, error) {
 	pollInterval := 2 * time.Second
-	timeout := 10 * time.Second
+	timeout := 60 * time.Second
 
 	log.Printf("Waiting up to %v for workflow run to be created", timeout)
 


### PR DESCRIPTION
A file already existing is conceptually an input error when asking to create a file. We ignore ToolInputError when replaying tool calls, because those errors are assumed to either be known errors from the original run or new errors unique to replay that, if replay calls are idempotent as they should be, won't impact the final state of the remote changes.

Also increasing the timeout for waiting for a new workflow run to be created, based on observed timeout.

Fixes #45 