### PR TITLE
Hook up version command to build-time variables

### DIFF
--- a/app/blundering-savant/cmd/version.go
+++ b/app/blundering-savant/cmd/version.go
@@ -6,11 +6,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version information set by main package
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	buildTime = "unknown"
+)
+
+// SetVersionInfo sets the version information from build-time variables
+func SetVersionInfo(v, commit, buildT string) {
+	version = v
+	gitCommit = commit
+	buildTime = buildT
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Blundering Savant Bot v1.0.0") // TODO version number
+		fmt.Printf("Blundering Savant Bot %s\n", version)
+		fmt.Printf("Git Commit: %s\n", gitCommit)
+		fmt.Printf("Build Time: %s\n", buildTime)
 	},
 }
 

--- a/app/blundering-savant/main.go
+++ b/app/blundering-savant/main.go
@@ -8,6 +8,13 @@ import (
 	"github.com/cchalm/blundering-savant/app/blundering-savant/cmd"
 )
 
+// Version information set by ldflags during build
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)
+
 // Config holds the configuration for the bot
 type Config struct {
 	// Authentication
@@ -28,6 +35,7 @@ type Config struct {
 }
 
 func main() {
+	cmd.SetVersionInfo(Version, GitCommit, BuildTime)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
Fixes #71 

This PR updates the version command to use actual build-time variables instead of a hardcoded version string.

## Changes Made

- **Added version variables to main.go**: Added `Version`, `GitCommit`, and `BuildTime` variables that can be set via ldflags during build
- **Created SetVersionInfo function**: Added a function in the cmd package to pass version information from main to the version command
- **Updated version command output**: Modified the version command to display:
  - Version (e.g., "Blundering Savant Bot v1.0.0")  
  - Git Commit hash
  - Build timestamp

## Implementation Details

The release workflow already sets these variables via ldflags:
```
-X main.Version=$VERSION -X main.GitCommit=$GIT_COMMIT -X main.BuildTime=$BUILD_TIME
```

The implementation provides sensible defaults ("dev", "unknown", "unknown") when the variables aren't set via ldflags, maintaining backward compatibility for development builds.

## Testing

The changes have been validated and maintain backward compatibility. When built with ldflags, the version command will show the actual build information. When built normally (e.g., during development), it will show the default values.

Fixes #71

---
*This PR was created by the Blundering Savant bot.*