### PR TITLE
Add repository text search tool to help bot find code faster

### DIFF
--- a/internal/bot/tools.go
+++ b/internal/bot/tools.go
@@ -853,7 +853,7 @@ func (t *SearchInFileTool) ParseToolUse(block anthropic.ToolUseBlock) (*SearchIn
 
 // Run executes the search in file command
 func (t *SearchInFileTool) Run(ctx context.Context, block anthropic.ToolUseBlock, toolCtx *ToolContext) (*string, error) {
-	return t.run(ctx, block, toolCtx, false)
+	return t.run(ctx, block, toolCtx)
 }
 
 func (t *SearchInFileTool) Replay(ctx context.Context, block anthropic.ToolUseBlock, toolCtx *ToolContext) error {
@@ -861,12 +861,7 @@ func (t *SearchInFileTool) Replay(ctx context.Context, block anthropic.ToolUseBl
 	return nil
 }
 
-func (t *SearchInFileTool) run(ctx context.Context, block anthropic.ToolUseBlock, toolCtx *ToolContext, replay bool) (*string, error) {
-	if replay {
-		// Search is read-only, no side effects to replay
-		return nil, nil
-	}
-
+func (t *SearchInFileTool) run(ctx context.Context, block anthropic.ToolUseBlock, toolCtx *ToolContext) (*string, error) {
 	input, err := t.ParseToolUse(block)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing input: %w", err)

--- a/internal/bot/tools.go
+++ b/internal/bot/tools.go
@@ -952,9 +952,13 @@ func (t *SearchInFileTool) searchInFile(filePath, content string, input *SearchI
 
 	lines := strings.Split(content, "\n")
 	resultCount := 0
+	maxResults := input.MaxResults
+	if maxResults <= 0 {
+		maxResults = 50 // Default if not set
+	}
 
 	for lineNum, line := range lines {
-		if resultCount >= input.MaxResults {
+		if resultCount >= maxResults {
 			break
 		}
 

--- a/internal/bot/tools.go
+++ b/internal/bot/tools.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"path/filepath"
 	"regexp"
 	"strings"
 

--- a/internal/bot/tools.go
+++ b/internal/bot/tools.go
@@ -919,11 +919,11 @@ func (t *SearchRepositoryTool) searchRepository(ctx context.Context, input *Sear
 
 	// Compile regex if needed
 	if input.UseRegex {
-		flags := 0
+		query := input.Query
 		if !input.CaseSensitive {
-			flags = regexp.IGNORECASE
+			query = "(?i)" + query
 		}
-		searchRegex, err = regexp.Compile(fmt.Sprintf("(?%s)%s", getFlagsString(flags), input.Query))
+		searchRegex, err = regexp.Compile(query)
 		if err != nil {
 			return nil, ToolInputError{fmt.Errorf("invalid regular expression: %w", err)}
 		}
@@ -1127,13 +1127,7 @@ func (t *SearchRepositoryTool) formatResults(results []SearchResult, input *Sear
 	return output.String()
 }
 
-// getFlagsString converts regex flags to string format
-func getFlagsString(flags int) string {
-	if flags&regexp.IGNORECASE != 0 {
-		return "i"
-	}
-	return ""
-}
+
 
 // ReportLimitationTool implements the report_limitation tool
 type ReportLimitationTool struct {

--- a/internal/bot/tools.go
+++ b/internal/bot/tools.go
@@ -892,7 +892,7 @@ func (t *SearchInFileTool) run(ctx context.Context, block anthropic.ToolUseBlock
 	if input.MaxResults > 200 {
 		input.MaxResults = 200
 	}
-	if input.ContextLines < 0 {
+	if input.ContextLines == 0 {
 		input.ContextLines = 2
 	}
 	if input.ContextLines > 10 {

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -91,7 +91,7 @@ func main() {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(results) != 1 {
-		t.Errorf("Expected 1 result, got %d", len(results))
+		t.Errorf("Expected 1 result, got %d. Content lines: %v", len(results), strings.Split(content, "\n"))
 	}
 	if results[0].LineNumber != 6 {
 		t.Errorf("Expected line number 6, got %d", results[0].LineNumber)

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -36,62 +36,7 @@ func TestDeleteFileTool_ParseInput_InvalidJSON(t *testing.T) {
 	testDeleteFileToolParseInput(t, invalidJSON, true)
 }
 
-// Mock workspace for testing
-type mockWorkspace struct {
-	files map[string]string
-	dirs  map[string][]string
-}
 
-func newMockWorkspace() *mockWorkspace {
-	return &mockWorkspace{
-		files: make(map[string]string),
-		dirs:  make(map[string][]string),
-	}
-}
-
-func (mw *mockWorkspace) addFile(path, content string) {
-	mw.files[path] = content
-}
-
-func (mw *mockWorkspace) addDir(path string, files []string) {
-	mw.dirs[path] = files
-}
-
-func (mw *mockWorkspace) Read(ctx context.Context, path string) (string, error) {
-	content, exists := mw.files[path]
-	if !exists {
-		return "", fmt.Errorf("file not found")
-	}
-	return content, nil
-}
-
-func (mw *mockWorkspace) Write(ctx context.Context, path string, content string) error {
-	mw.files[path] = content
-	return nil
-}
-
-func (mw *mockWorkspace) Delete(ctx context.Context, path string) error {
-	delete(mw.files, path)
-	return nil
-}
-
-func (mw *mockWorkspace) FileExists(ctx context.Context, path string) (bool, error) {
-	_, exists := mw.files[path]
-	return exists, nil
-}
-
-func (mw *mockWorkspace) IsDir(ctx context.Context, path string) (bool, error) {
-	_, exists := mw.dirs[path]
-	return exists, nil
-}
-
-func (mw *mockWorkspace) ListDir(ctx context.Context, path string) ([]string, error) {
-	files, exists := mw.dirs[path]
-	if !exists {
-		return nil, fmt.Errorf("directory not found")
-	}
-	return files, nil
-}
 
 func testSearchRepositoryToolParseInput(t *testing.T, inputJSON []byte, wantError bool) {
 	tool := NewSearchRepositoryTool()

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -92,12 +92,7 @@ func main() {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(results) != 1 {
-		lines := strings.Split(content, "\n")
 		t.Errorf("Expected 1 result, got %d", len(results))
-		for i, line := range lines {
-			contains := strings.Contains(line, "fmt.Println")
-			t.Errorf("Line %d: %q - contains 'fmt.Println': %v", i+1, line, contains)
-		}
 	}
 	if results[0].LineNumber != 6 {
 		t.Errorf("Expected line number 6, got %d", results[0].LineNumber)

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -1,8 +1,6 @@
 package bot
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -92,7 +92,12 @@ func main() {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if len(results) != 1 {
-		t.Errorf("Expected 1 result, got %d. Content lines: %v", len(results), strings.Split(content, "\n"))
+		lines := strings.Split(content, "\n")
+		t.Errorf("Expected 1 result, got %d", len(results))
+		for i, line := range lines {
+			contains := strings.Contains(line, "fmt.Println")
+			t.Errorf("Line %d: %q - contains 'fmt.Println': %v", i+1, line, contains)
+		}
 	}
 	if results[0].LineNumber != 6 {
 		t.Errorf("Expected line number 6, got %d", results[0].LineNumber)

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -1,7 +1,6 @@
 package bot
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"

--- a/internal/bot/tools_test.go
+++ b/internal/bot/tools_test.go
@@ -1,6 +1,8 @@
 package bot
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -32,4 +34,182 @@ func TestDeleteFileTool_ParseInput_ValidJSON(t *testing.T) {
 func TestDeleteFileTool_ParseInput_InvalidJSON(t *testing.T) {
 	invalidJSON := []byte(`{"path": "test.txt"`) // Missing closing brace
 	testDeleteFileToolParseInput(t, invalidJSON, true)
+}
+
+// Mock workspace for testing
+type mockWorkspace struct {
+	files map[string]string
+	dirs  map[string][]string
+}
+
+func newMockWorkspace() *mockWorkspace {
+	return &mockWorkspace{
+		files: make(map[string]string),
+		dirs:  make(map[string][]string),
+	}
+}
+
+func (mw *mockWorkspace) addFile(path, content string) {
+	mw.files[path] = content
+}
+
+func (mw *mockWorkspace) addDir(path string, files []string) {
+	mw.dirs[path] = files
+}
+
+func (mw *mockWorkspace) Read(ctx context.Context, path string) (string, error) {
+	content, exists := mw.files[path]
+	if !exists {
+		return "", fmt.Errorf("file not found")
+	}
+	return content, nil
+}
+
+func (mw *mockWorkspace) Write(ctx context.Context, path string, content string) error {
+	mw.files[path] = content
+	return nil
+}
+
+func (mw *mockWorkspace) Delete(ctx context.Context, path string) error {
+	delete(mw.files, path)
+	return nil
+}
+
+func (mw *mockWorkspace) FileExists(ctx context.Context, path string) (bool, error) {
+	_, exists := mw.files[path]
+	return exists, nil
+}
+
+func (mw *mockWorkspace) IsDir(ctx context.Context, path string) (bool, error) {
+	_, exists := mw.dirs[path]
+	return exists, nil
+}
+
+func (mw *mockWorkspace) ListDir(ctx context.Context, path string) ([]string, error) {
+	files, exists := mw.dirs[path]
+	if !exists {
+		return nil, fmt.Errorf("directory not found")
+	}
+	return files, nil
+}
+
+func testSearchRepositoryToolParseInput(t *testing.T, inputJSON []byte, wantError bool) {
+	tool := NewSearchRepositoryTool()
+	block := anthropic.ToolUseBlock{
+		ID:    "test",
+		Name:  "search_repository",
+		Input: inputJSON,
+	}
+
+	result, err := tool.ParseToolUse(block)
+	if (err != nil) != wantError {
+		t.Errorf("ParseToolUse() error = %v, wantError %v", err, wantError)
+	}
+
+	if !wantError && result == nil {
+		t.Error("Expected non-nil result for successful parse")
+	}
+}
+
+func TestSearchRepositoryTool_ParseInput_ValidJSON(t *testing.T) {
+	validJSON := []byte(`{"query": "func main", "use_regex": false, "max_results": 10}`)
+	testSearchRepositoryToolParseInput(t, validJSON, false)
+}
+
+func TestSearchRepositoryTool_ParseInput_MinimalValidJSON(t *testing.T) {
+	validJSON := []byte(`{"query": "test"}`)
+	testSearchRepositoryToolParseInput(t, validJSON, false)
+}
+
+func TestSearchRepositoryTool_ParseInput_InvalidJSON(t *testing.T) {
+	invalidJSON := []byte(`{"query": "test"`) // Missing closing brace
+	testSearchRepositoryToolParseInput(t, invalidJSON, true)
+}
+
+func TestSearchRepositoryTool_shouldSearchFile(t *testing.T) {
+	tool := NewSearchRepositoryTool()
+
+	// Test with no filters
+	input := &SearchRepositoryInput{Query: "test"}
+	if !tool.shouldSearchFile("test.go", input) {
+		t.Error("Expected to search file with no filters")
+	}
+
+	// Test with file extension filter
+	input = &SearchRepositoryInput{
+		Query:          "test",
+		FileExtensions: []string{"go", "md"},
+	}
+	if !tool.shouldSearchFile("test.go", input) {
+		t.Error("Expected to search .go file with go extension filter")
+	}
+	if tool.shouldSearchFile("test.txt", input) {
+		t.Error("Expected not to search .txt file with go extension filter")
+	}
+
+	// Test with path filter
+	input = &SearchRepositoryInput{
+		Query:      "test",
+		PathFilter: "internal/*",
+	}
+	if !tool.shouldSearchFile("internal/test.go", input) {
+		t.Error("Expected to search file matching path filter")
+	}
+}
+
+func TestSearchRepositoryTool_searchInFile(t *testing.T) {
+	tool := NewSearchRepositoryTool()
+	content := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+	fmt.Printf("Testing search functionality")
+}`
+
+	// Test basic string search
+	input := &SearchRepositoryInput{
+		Query:        "fmt.Println",
+		ContextLines: 1,
+	}
+	results := tool.searchInFile("test.go", content, input, nil)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result, got %d", len(results))
+	}
+	if results[0].LineNumber != 6 {
+		t.Errorf("Expected line number 6, got %d", results[0].LineNumber)
+	}
+	if len(results[0].ContextBefore) != 1 {
+		t.Errorf("Expected 1 context line before, got %d", len(results[0].ContextBefore))
+	}
+	if len(results[0].ContextAfter) != 1 {
+		t.Errorf("Expected 1 context line after, got %d", len(results[0].ContextAfter))
+	}
+
+	// Test case insensitive search
+	input = &SearchRepositoryInput{
+		Query:         "FUNC MAIN",
+		CaseSensitive: false,
+	}
+	results = tool.searchInFile("test.go", content, input, nil)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 case insensitive result, got %d", len(results))
+	}
+}
+
+func TestSearchRepositoryTool_isBinaryFile(t *testing.T) {
+	tool := NewSearchRepositoryTool()
+
+	// Test text file
+	textContent := "This is a normal text file"
+	if tool.isBinaryFile(textContent) {
+		t.Error("Expected text content to not be detected as binary")
+	}
+
+	// Test binary file (with null bytes)
+	binaryContent := "This has null bytes\x00here"
+	if !tool.isBinaryFile(binaryContent) {
+		t.Error("Expected content with null bytes to be detected as binary")
+	}
 }


### PR DESCRIPTION
This PR implements a repository text search tool to address issue #43, where the bot struggles to find type definitions and other specific pieces of code efficiently.

## What's Changed

### New `search_repository` Tool
- **Purpose**: Search for text across all files in the repository, similar to Ctrl+Shift+F in VS Code
- **Features**:
  - Text and regex search capabilities
  - File filtering by path patterns (glob support) and extensions  
  - Configurable result limits (default: 50, max: 500)
  - Context lines around matches (configurable, max: 10)
  - Case sensitive/insensitive search options
  - Binary file detection and optional filtering
  - Formatted results with file paths, line numbers, and context

### Implementation Details
- Added `SearchRepositoryTool` to `internal/bot/tools.go`
- Integrated with existing `Workspace` interface through `workspace.FileSystem`
- Recursive file traversal with proper error handling
- Comprehensive input validation and error reporting
- Follows Go style guide conventions and project patterns

### Testing
- Unit tests for input parsing and validation
- Tests for file filtering logic (path patterns, extensions)
- Tests for search functionality (basic text, case sensitivity)
- Tests for binary file detection
- All tests pass and code passes linting

## Benefits
- **Performance**: Dramatically reduces the number of tool calls needed to find specific code
- **Accuracy**: Helps the bot locate type definitions, function implementations, and other code elements quickly
- **Usability**: Intuitive interface similar to familiar IDE search functionality
- **Flexibility**: Supports both simple text search and advanced regex patterns

## Example Usage
```json
{
  "query": "type GitHubClient",
  "file_extensions": ["go"],
  "max_results": 10,
  "context_lines": 2
}
```

This addresses the core issue where the bot was taking 21+ tool calls to find a single type definition in a small repository.

Fixes #43

---
*This PR was created by the Blundering Savant bot.*